### PR TITLE
Add 1kb.tham.es

### DIFF
--- a/_site_listings/1kb.tham.es
+++ b/_site_listings/1kb.tham.es
@@ -1,0 +1,4 @@
+---
+pageurl: 1kb.tham.es
+size: 990
+---

--- a/_site_listings/1kb.tham.es.md
+++ b/_site_listings/1kb.tham.es.md
@@ -1,4 +1,4 @@
 ---
 pageurl: 1kb.tham.es
-size: 990
+size: 653
 ---


### PR DESCRIPTION
The [GTmetrix Performance Report](https://gtmetrix.com/reports/1kb.tham.es/3dhBmmfR/) indicates .99KB (not very exact).

This is sad, because the source is _exactly_ a cool 777B.

I think this might be one of the first with a favicon.