### PR TITLE
Replace 1kb.tham.es with richardthames.com

### DIFF
--- a/_site_listings/1kb.tham.es.md
+++ b/_site_listings/1kb.tham.es.md
@@ -1,4 +1,0 @@
----
-pageurl: 1kb.tham.es
-size: 653
----

--- a/_site_listings/richardthames.com.md
+++ b/_site_listings/richardthames.com.md
@@ -1,0 +1,4 @@
+---
+pageurl: richardthames.com
+size: 894
+---


### PR DESCRIPTION
This PR replaces my original entry with a new page/domain that includes more features.

GTMetrix varies, but last 5 are: [894B](https://gtmetrix.com/reports/richardthames.com/yBjf1qZ9/), [895B](https://gtmetrix.com/reports/richardthames.com/Sp2lZ9yJ/), [894B](https://gtmetrix.com/reports/richardthames.com/529QoTIM/), [894B](https://gtmetrix.com/reports/richardthames.com/CeVk3xSN/), and [894B](https://gtmetrix.com/reports/richardthames.com/P2FmUy5H/).